### PR TITLE
updated max upload size

### DIFF
--- a/Encryntion/src/main/resources/application.properties
+++ b/Encryntion/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 #logging.level.feign=DEBUG
 #logging.level.org.springframework.web=DEBUG
 spring.servlet.multipart.max-file-size=11MB
-spring.servlet.multipart.max-request-size=25MB
+spring.servlet.multipart.max-request-size=15MB
 
 
 server.port=8090


### PR DESCRIPTION
updated the max upload size of the image for encryption from 25MB to 15MB